### PR TITLE
fix: register loading login flow

### DIFF
--- a/lib/KindeAuthProvider.tsx
+++ b/lib/KindeAuthProvider.tsx
@@ -78,7 +78,6 @@ export const KindeAuthProvider = ({
       extraParams: {
         ...mapLoginMethodParamsForUrl(options),
         has_success_page: "true",
-        prompt: "login",
       },
     });
 


### PR DESCRIPTION
# Explain your changes

Prompt was getting overridden in authenticate method which caused the `create` prompt not to work

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
