### PR TITLE
fix: `expo export` script failing for web

### DIFF
--- a/lib/KindeAuthProvider.tsx
+++ b/lib/KindeAuthProvider.tsx
@@ -29,9 +29,12 @@ export const KindeAuthContext = createContext<KindeAuthHook | undefined>(
   undefined,
 );
 
-// Polyfill for atob
-global.btoa = encode;
-global.atob = decode;
+// global is unavailable for web `expo export` script
+if (typeof global !== "undefined") {
+  // Polyfill for atob
+  global.btoa = encode;
+  global.atob = decode;
+}
 
 export const KindeAuthProvider = ({
   children,


### PR DESCRIPTION
# Explain your changes

We were experiencing an error "Metro error: window is not defined" when using the `expo export` script. We're specially using the export script for Expo router API routes but this would also impact users using expo web builds needing to use the `expo export` script.

To reproduce the error:
- Create a new expo project with `npx create-expo-app@latest`
- Install `pnpm @kinde-oss/expo`
- Import and use a `@kinde-oss/expo` component such as `KindeAuthProvider`
- Run `npx expo export`

I have published this to an internal package and it has fixed the `expo export` script.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
