### PR TITLE
Fixes undefined config variables in standalone builds leading to crashes

### DIFF
--- a/lib/KindeAuthProvider.tsx
+++ b/lib/KindeAuthProvider.tsx
@@ -35,14 +35,24 @@ global.atob = decode;
 
 export const KindeAuthProvider = ({
   children,
+  config,
 }: {
   children: React.ReactNode;
+  config: {
+    domain: string | undefined;
+    clientId: string | undefined;
+    scopes?: string;
+  };
 }) => {
-  const domain = process.env.EXPO_PUBLIC_KINDE_DOMAIN!;
-  const clientId = process.env.EXPO_PUBLIC_KINDE_CLIENT_ID!;
-  const scopes =
-    process.env.EXPO_PUBLIC_KINDE_SCOPES?.split(" ") ||
-    DEFAULT_TOKEN_SCOPES.split(" ");
+  const domain = config.domain;
+  if (domain === undefined)
+    throw new Error("KindeAuthProvider config.domain prop is undefined");
+
+  const clientId = config.clientId;
+  if (clientId === undefined)
+    throw new Error("KindeAuthProvider config.clientId prop is undefined");
+
+  const scopes = config.scopes?.split(" ") || DEFAULT_TOKEN_SCOPES.split(" ");
 
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const redirectUri = makeRedirectUri({ native: Constants.isDevice });

--- a/readme.md
+++ b/readme.md
@@ -12,13 +12,6 @@ pnpm add @kinde/expo
 
 ## **Environment variables**
 
-```bash
-EXPO_PUBLIC_KINDE_DOMAIN=[yourapp.kinde.com]
-EXPO_PUBLIC_KINDE_CLIENT_ID="ApplicationClientId"
-// Optional (default: "openid profile email offline")
-EXPO_PUBLIC_KINDE_SCOPES="openid profile email offline"
-```
-
 The redirection URL is automatically computed using Expo Auth Session `makeRedirectUri` function. You can find more information about this function [here](https://docs.expo.dev/versions/latest/sdk/auth-session/#makeRedirectUri).
 
 ## Integrate with your app
@@ -30,7 +23,12 @@ import { KindeAuthProvider } from '@kinde/expo';
 
 export default function App() {
   return (
-    <KindeAuthProvider>
+    <KindeAuthProvider config={{
+       domain: "your-app.kinde.com", // Required
+       clientId: "your-client-id", // Required
+       // Optional (default: "openid profile email offline")
+       scopes: "openid profile email offline",
+     }}>
       <!-- Your application code -->
     </KindeAuthProvider>
   );


### PR DESCRIPTION
# Explain your changes

This PR passes configuration variables via a `KindeAuthProvider` config prop rather than accessing them internally via `process.env`.

We were having issues with this lib working fine locally but crashing within a standalone build, such as TestFlight or a simulator build, when login or register is called. 

It appears to be due to how expo handles `EXPO_PUBLIC_` variables. As noted in the [expo docs](https://docs.expo.dev/guides/environment-variables/#how-variables-are-loaded), `EXPO_PUBLIC_` variables are replaced in your code but not within `node_modules`. Though `node_modules` `EXPO_PUBLIC_` variables appear to load when running your project locally.

I've deployed this to a private package for testing with an iOS simulator build and it has fixed our issue.

May fix issue #4 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
