### PR TITLE
fix: js-utils external vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         "expo-secure-store",
         "expo-web-browser",
         "@kinde/jwt-validator",
+        "@kinde/js-utils",
       ],
       output: {
         globals: {


### PR DESCRIPTION
# Explain your changes

Added `@kinde/js-utils` as external to improve Expo 51 and 52 compatibility.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
