### PR TITLE
fix: respect redirect uri config

### DIFF
--- a/lib/KindeAuthProvider.tsx
+++ b/lib/KindeAuthProvider.tsx
@@ -182,7 +182,8 @@ export const KindeAuthProvider = ({
   const authenticate = async (
     options: Partial<LoginMethodParams> = {},
   ): Promise<LoginResponse> => {
-    if (!redirectUri) {
+    const authRedirectUri = options.redirectURL || redirectUri;
+    if (!authRedirectUri) {
       return {
         success: false,
         errorMessage: "This library only works on a mobile device",
@@ -198,7 +199,7 @@ export const KindeAuthProvider = ({
 
     const request = new AuthRequest({
       clientId,
-      redirectUri,
+      redirectUri: authRedirectUri,
       scopes: scopes,
       extraParams: {
         ...mapLoginMethodParamsForUrl(options),
@@ -223,7 +224,7 @@ export const KindeAuthProvider = ({
             extraParams: request.codeVerifier
               ? { code_verifier: request.codeVerifier }
               : undefined,
-            redirectUri,
+            redirectUri: authRedirectUri,
           },
           { tokenEndpoint: `${domain}/oauth2/token` },
         );


### PR DESCRIPTION
# Explain your changes

Currently the `redirectUri` passed to `login` and `register` are not respected by the SDK and defaults to the one created by `makeRedirectUri()`. This PR fixes it to actually respect the `redirectUri` config, if passed.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

