### PR TITLE
fix: upgrade @kinde/js-utils to ^0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "@kinde/js-utils": "0.18.3",
+    "@kinde/js-utils": "^0.26.0",
     "@kinde/jwt-decoder": "^0.2.0",
     "@kinde/jwt-validator": "^0.4.0",
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
Upgrades @kinde/js-utils to pick up the fix for the async forEach bug in ExpoSecureStore.setSessionItem() that caused token refresh race conditions. This resolves issues where token writes weren't completing before subsequent reads, leading to 403 errors after app reloads.