### PR TITLE
fix: store tokens with AFTER_FIRST_UNLOCK keychain accessibility on iOS

### DIFF
--- a/lib/storage/ExpoSecureStore.test.ts
+++ b/lib/storage/ExpoSecureStore.test.ts
@@ -6,6 +6,7 @@ vi.mock("expo-secure-store", () => ({
   setItemAsync: vi.fn(),
   getItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
+  AFTER_FIRST_UNLOCK: "AFTER_FIRST_UNLOCK",
 }));
 
 import * as SecureStore from "expo-secure-store";
@@ -32,6 +33,7 @@ describe("ExpoSecureStore", () => {
     expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith(
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       token,
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
   });
 
@@ -103,11 +105,13 @@ describe("ExpoSecureStore", () => {
       1,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       "a".repeat(chunkSize),
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
     expect(mockedSecureStore.setItemAsync).toHaveBeenNthCalledWith(
       2,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}1`,
       "a",
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
   });
 

--- a/lib/storage/ExpoSecureStore.ts
+++ b/lib/storage/ExpoSecureStore.ts
@@ -74,6 +74,12 @@ export class ExpoSecureStore<
         expoSecureStore!.setItemAsync(
           `${storageSettings.keyPrefix}${itemKey}${index}`,
           splitValue,
+          {
+            // iOS: tokens must stay readable when the device is locked (e.g.
+            // a refresh firing right after lock), which the default
+            // WHEN_UNLOCKED accessibility forbids.
+            keychainAccessible: expoSecureStore!.AFTER_FIRST_UNLOCK,
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Problem

Tokens are written via `SecureStore.setItemAsync(key, value)` with no options, so they get expo-secure-store's default `kSecAttrAccessibleWhenUnlocked`. Any keychain read while the device is locked then throws:

```
FunctionCallException: Calling the 'getValueWithKeyAsync' function has failed
  → Caused by: KeyChainException: User interaction is not allowed. (ExpoSecureStore)
```

In practice this fires when a token refresh runs in the short window after the user locks the device (before iOS suspends the app), and consistently in apps with background execution (background fetch/tasks, silent push). The rejection escapes as an unhandled rejection and can surface as a spurious `ERR_REFRESH`. Reported by a customer via Bugsnag on `@kinde/expo@0.8.0` / Expo SDK 56 / iOS.

## Fix

Write all token chunks with `keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK` — the standard accessibility class for OAuth refresh tokens that background code must read ([Apple docs](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlock)). Tokens remain protected before the first unlock after boot but stay readable while the device is locked afterwards.

## Migration / compatibility

- **Existing installs migrate automatically on the next token write**: `setSessionItem` deletes old chunks before writing, so every write is a fresh `SecItemAdd` carrying the new attribute (verified against expo-secure-store's native `set`/`update` implementation, which only updates `kSecValueData` in place).
- **Reads of pre-upgrade items are unaffected**: the native keychain search query does not filter on `kSecAttrAccessible`.
- **Android is unaffected**: `keychainAccessible` is iOS-only.
- Backup migration semantics are unchanged (`WHEN_UNLOCKED` → `AFTER_FIRST_UNLOCK` are both migrating classes).

A follow-up PR will handle the residual case (reads before first unlock after reboot, e.g. iOS prewarming) by treating keychain-unavailable errors as transient in the refresh path instead of letting them escape as unhandled rejections.

## Testing

- Updated `ExpoSecureStore` unit tests to assert the accessibility option on writes.
- Full suite: 52/52 passing; lint and build clean.