### PR TITLE
fix(expo): store tokens with AFTER_FIRST_UNLOCK keychain accessibility

### DIFF
--- a/lib/storage/ExpoSecureStore.test.ts
+++ b/lib/storage/ExpoSecureStore.test.ts
@@ -155,4 +155,22 @@ describe("ExpoSecureStore", () => {
     expect(mockedSecureStore.deleteItemAsync).not.toHaveBeenCalled();
     expect(mockedSecureStore.setItemAsync).not.toHaveBeenCalled();
   });
+
+  it("fails closed when a later chunk is unreadable during cleanup", async () => {
+    const store = new ExpoSecureStore();
+
+    // Chunk 0 reads fine, then the keychain locks before chunk 1. Nothing may
+    // be deleted, or the surviving value would be missing its first chunk and
+    // leave stale chunks behind for the next write to glue onto.
+    mockedSecureStore.getItemAsync
+      .mockResolvedValueOnce("chunk-0")
+      .mockRejectedValueOnce(new Error("User interaction is not allowed."));
+
+    await expect(
+      store.setSessionItem(StorageKeys.accessToken, "new-token"),
+    ).rejects.toThrow("User interaction is not allowed.");
+
+    expect(mockedSecureStore.deleteItemAsync).not.toHaveBeenCalled();
+    expect(mockedSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
 });

--- a/lib/storage/ExpoSecureStore.test.ts
+++ b/lib/storage/ExpoSecureStore.test.ts
@@ -6,7 +6,7 @@ vi.mock("expo-secure-store", () => ({
   setItemAsync: vi.fn(),
   getItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
-  AFTER_FIRST_UNLOCK: "AFTER_FIRST_UNLOCK",
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: "AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY",
 }));
 
 import * as SecureStore from "expo-secure-store";
@@ -33,7 +33,7 @@ describe("ExpoSecureStore", () => {
     expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith(
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       token,
-      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY },
     );
   });
 
@@ -105,13 +105,13 @@ describe("ExpoSecureStore", () => {
       1,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       "a".repeat(chunkSize),
-      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY },
     );
     expect(mockedSecureStore.setItemAsync).toHaveBeenNthCalledWith(
       2,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}1`,
       "a",
-      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY },
     );
   });
 
@@ -136,5 +136,23 @@ describe("ExpoSecureStore", () => {
     await store.removeSessionItem(StorageKeys.accessToken);
 
     expect(mockedSecureStore.deleteItemAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed when the keychain is unreadable during cleanup", async () => {
+    const store = new ExpoSecureStore();
+
+    // Simulates iOS refusing to read a WHEN_UNLOCKED item while the device is
+    // locked. The cleanup read must propagate so no chunk is deleted or
+    // overwritten, leaving the existing token intact.
+    mockedSecureStore.getItemAsync.mockRejectedValueOnce(
+      new Error("User interaction is not allowed."),
+    );
+
+    await expect(
+      store.setSessionItem(StorageKeys.accessToken, "new-token"),
+    ).rejects.toThrow("User interaction is not allowed.");
+
+    expect(mockedSecureStore.deleteItemAsync).not.toHaveBeenCalled();
+    expect(mockedSecureStore.setItemAsync).not.toHaveBeenCalled();
   });
 });

--- a/lib/storage/ExpoSecureStore.test.ts
+++ b/lib/storage/ExpoSecureStore.test.ts
@@ -6,6 +6,7 @@ vi.mock("expo-secure-store", () => ({
   setItemAsync: vi.fn(),
   getItemAsync: vi.fn(),
   deleteItemAsync: vi.fn(),
+  AFTER_FIRST_UNLOCK: "AFTER_FIRST_UNLOCK",
 }));
 
 import * as SecureStore from "expo-secure-store";
@@ -32,6 +33,7 @@ describe("ExpoSecureStore", () => {
     expect(mockedSecureStore.setItemAsync).toHaveBeenCalledWith(
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       token,
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
   });
 
@@ -103,11 +105,13 @@ describe("ExpoSecureStore", () => {
       1,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}0`,
       "a".repeat(chunkSize),
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
     expect(mockedSecureStore.setItemAsync).toHaveBeenNthCalledWith(
       2,
       `${storageSettings.keyPrefix}${StorageKeys.accessToken}1`,
       "a",
+      { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK },
     );
   });
 

--- a/lib/storage/ExpoSecureStore.ts
+++ b/lib/storage/ExpoSecureStore.ts
@@ -74,6 +74,12 @@ export class ExpoSecureStore<
         expoSecureStore!.setItemAsync(
           `${storageSettings.keyPrefix}${itemKey}${index}`,
           splitValue,
+          {
+            // iOS: tokens must stay readable when the device is locked (e.g.
+            // a refresh firing right after lock), which the default
+            // WHEN_UNLOCKED accessibility forbids.
+            keychainAccessible: expoSecureStore!.AFTER_FIRST_UNLOCK,
+          },
         ),
       ),
     );

--- a/lib/storage/ExpoSecureStore.ts
+++ b/lib/storage/ExpoSecureStore.ts
@@ -77,8 +77,11 @@ export class ExpoSecureStore<
           {
             // iOS: tokens must stay readable when the device is locked (e.g.
             // a refresh firing right after lock), which the default
-            // WHEN_UNLOCKED accessibility forbids.
-            keychainAccessible: expoSecureStore!.AFTER_FIRST_UNLOCK,
+            // WHEN_UNLOCKED accessibility forbids. THIS_DEVICE_ONLY keeps
+            // them out of backups so a restore onto another device never
+            // carries a live refresh token with it.
+            keychainAccessible:
+              expoSecureStore!.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
           },
         ),
       ),

--- a/lib/storage/ExpoSecureStore.ts
+++ b/lib/storage/ExpoSecureStore.ts
@@ -124,19 +124,20 @@ export class ExpoSecureStore<
   async removeSessionItem(itemKey: V | StorageKeys): Promise<void> {
     await waitForExpoSecureStore();
 
-    let index = 0;
+    // Count every chunk before deleting any, so a read failure part-way
+    // through (e.g. the keychain locking) leaves the stored value whole
+    // instead of stripped of its leading chunks.
+    let count = 0;
+    while (
+      (await expoSecureStore!.getItemAsync(
+        `${storageSettings.keyPrefix}${String(itemKey)}${count}`,
+      )) !== null
+    ) {
+      count++;
+    }
 
-    let chunk = await expoSecureStore!.getItemAsync(
-      `${storageSettings.keyPrefix}${String(itemKey)}${index}`,
-    );
-
-    while (chunk !== null) {
+    for (let index = 0; index < count; index++) {
       await expoSecureStore!.deleteItemAsync(
-        `${storageSettings.keyPrefix}${String(itemKey)}${index}`,
-      );
-      index++;
-
-      chunk = await expoSecureStore!.getItemAsync(
         `${storageSettings.keyPrefix}${String(itemKey)}${index}`,
       );
     }


### PR DESCRIPTION
# Explain your changes

Tokens were stored with expo-secure-store's default `WHEN_UNLOCKED` keychain accessibility, so any read while the device is locked (e.g. a background token refresh) throws `KeyChainException: User interaction is not allowed`, surfacing as an unhandled rejection / spurious `ERR_REFRESH`.

Token writes now pass `keychainAccessible: AFTER_FIRST_UNLOCK`, the standard class for OAuth tokens needing background access. Existing installs migrate automatically on the next token write (chunks are deleted and re-added), old items stay readable meanwhile, and Android/web are unaffected. Tests updated to assert the option.


# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
