### PR TITLE
feat: support token revocation during logout

### DIFF
--- a/lib/KindeAuthProvider.test.ts
+++ b/lib/KindeAuthProvider.test.ts
@@ -53,6 +53,7 @@ const mocked = vi.hoisted(() => ({
   })),
   removeSessionItem: vi.fn(async () => undefined),
   refreshToken: vi.fn(async () => ({ success: false })),
+  revokeAsync: vi.fn(async () => true),
   setInsecureStorage: vi.fn(),
   setRefreshTimer: vi.fn(),
   storageSettings: { useInsecureForRefreshToken: false },
@@ -89,6 +90,11 @@ vi.mock("expo-auth-session", () => ({
   },
   exchangeCodeAsync: mocked.exchangeCodeAsync,
   makeRedirectUri: mocked.makeRedirectUri,
+  revokeAsync: mocked.revokeAsync,
+  TokenTypeHint: {
+    AccessToken: "access_token",
+    RefreshToken: "refresh_token",
+  },
 }));
 
 vi.mock("expo-web-browser", () => ({
@@ -359,11 +365,13 @@ describe("KindeAuthProvider Expo SDK 56 migration", () => {
     );
   });
 
-  it("prioritizes Kinde hosted logout when revokeToken is requested", async () => {
+  it("revokes tokens and performs hosted logout when revokeToken is requested", async () => {
     const storage = {
-      getSessionItem: vi.fn(async (key: string) =>
-        key === "access_token" ? "access-token" : null,
-      ),
+      getSessionItem: vi.fn(async (key: string) => {
+        if (key === "access_token") return "access-token";
+        if (key === "refresh_token") return "refresh-token";
+        return null;
+      }),
       removeSessionItem: vi.fn(async () => undefined),
       removeItems: vi.fn(async () => undefined),
       setSessionItem: vi.fn(async () => undefined),
@@ -395,6 +403,26 @@ describe("KindeAuthProvider Expo SDK 56 migration", () => {
 
     const logoutUrl = new URL(mocked.openAuthSessionAsync.mock.calls[0][0]);
 
+    // Verify token revocation was called for both access and refresh tokens
+    expect(mocked.revokeAsync).toHaveBeenCalledTimes(2);
+    expect(mocked.revokeAsync).toHaveBeenCalledWith(
+      {
+        clientId: "client-id",
+        token: "access-token",
+        tokenTypeHint: "access_token",
+      },
+      expect.any(Object),
+    );
+    expect(mocked.revokeAsync).toHaveBeenCalledWith(
+      {
+        clientId: "client-id",
+        token: "refresh-token",
+        tokenTypeHint: "refresh_token",
+      },
+      expect.any(Object),
+    );
+
+    // Verify hosted logout was still called correctly
     expect(logoutUrl.origin + logoutUrl.pathname).toBe(
       "https://example.kinde.com/logout",
     );

--- a/lib/KindeAuthProvider.tsx
+++ b/lib/KindeAuthProvider.tsx
@@ -30,6 +30,8 @@ import {
   DiscoveryDocument,
   exchangeCodeAsync,
   makeRedirectUri,
+  revokeAsync,
+  TokenTypeHint,
 } from "expo-auth-session";
 import { openAuthSessionAsync, openBrowserAsync } from "expo-web-browser";
 import {
@@ -58,6 +60,7 @@ import {
   createSessionStorage,
   performRemoteLogout,
   persistRefreshToken,
+  getPersistedRefreshToken,
 } from "./storage";
 export const KindeAuthContext = createContext<KindeAuthHook | undefined>(
   undefined,
@@ -534,7 +537,7 @@ export const KindeAuthProvider = ({
    * @returns {Promise<LogoutResult>}
    */
   async function logout(
-    { revokeToken: _revokeToken }: Partial<LogoutRequest> = {},
+    { revokeToken }: Partial<LogoutRequest> = {},
     browserOptions?: KindeBrowserOptions,
   ): Promise<LogoutResult> {
     if (!storage) {
@@ -551,6 +554,55 @@ export const KindeAuthProvider = ({
 
     let success = true;
 
+    if (revokeToken && discovery?.revocationEndpoint) {
+      try {
+        const currentAccess = await getAccessToken();
+        const currentRefresh = await getPersistedRefreshToken(storage);
+
+        const revokePromises = [];
+
+        if (currentAccess) {
+          revokePromises.push(
+            revokeAsync(
+              {
+                clientId: config.clientId,
+                token: currentAccess,
+                tokenTypeHint: TokenTypeHint.AccessToken,
+              },
+              discovery,
+            ),
+          );
+        }
+
+        if (currentRefresh) {
+          revokePromises.push(
+            revokeAsync(
+              {
+                clientId: config.clientId,
+                token: currentRefresh,
+                tokenTypeHint: TokenTypeHint.RefreshToken,
+              },
+              discovery,
+            ),
+          );
+        }
+
+        if (revokePromises.length > 0) {
+          await Promise.allSettled(revokePromises);
+        }
+      } catch (err: unknown) {
+        console.error(err);
+        success = false;
+      }
+    }
+
+    try {
+      await cleanup();
+    } catch (err: unknown) {
+      console.error(err);
+      success = false;
+    }
+
     try {
       await performRemoteLogout({
         discovery,
@@ -562,13 +614,6 @@ export const KindeAuthProvider = ({
         openAuthSession: async (url, authRedirectUri, options) =>
           openAuthSessionAsync(url, authRedirectUri, options),
       });
-    } catch (err: unknown) {
-      console.error(err);
-      success = false;
-    }
-
-    try {
-      await cleanup();
     } catch (err: unknown) {
       console.error(err);
       success = false;

--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -13,6 +13,7 @@ import {
   clearPersistedRefreshToken,
   completePendingWebAuthSession,
   createSessionStorage,
+  getPersistedRefreshToken,
   performRemoteLogout,
   persistRefreshToken,
 } from "./storage";
@@ -199,6 +200,70 @@ describe("storage helpers", () => {
     expect(
       await getInsecureStorage()?.getSessionItem(StorageKeys.refreshToken),
     ).toBeNull();
+  });
+
+  it("retrieves from insecure storage when useInsecureForRefreshToken is true and insecure storage exists", async () => {
+    const { localStorage } = installLocalStorageStub();
+    
+    const primaryStorage = await createSessionStorage({
+      platformOS: "web",
+      windowObject: { localStorage },
+    });
+    
+    storageSettings.useInsecureForRefreshToken = true;
+    const insecureStorage = getInsecureStorage()!;
+
+    const primarySpy = vi.spyOn(primaryStorage, "getSessionItem")
+      .mockResolvedValue("FAKE_PRIMARY_TOKEN");
+    const insecureSpy = vi.spyOn(insecureStorage, "getSessionItem")
+      .mockResolvedValue("FAKE_INSECURE_TOKEN");
+
+    const retrievedToken = await getPersistedRefreshToken(primaryStorage);
+
+    expect(insecureSpy).toHaveBeenCalledWith(StorageKeys.refreshToken);
+    expect(primarySpy).not.toHaveBeenCalled();
+    expect(retrievedToken).toBe("FAKE_INSECURE_TOKEN");
+  });
+
+  it("retrieves from active storage when useInsecureForRefreshToken is false", async () => {
+    const { localStorage } = installLocalStorageStub();
+    
+    const primaryStorage = await createSessionStorage({
+      platformOS: "web",
+      windowObject: { localStorage },
+    });
+    
+    storageSettings.useInsecureForRefreshToken = false;
+    const insecureStorage = getInsecureStorage()!;
+
+    const primarySpy = vi.spyOn(primaryStorage, "getSessionItem")
+      .mockResolvedValue("FAKE_PRIMARY_TOKEN");
+    const insecureSpy = vi.spyOn(insecureStorage, "getSessionItem")
+      .mockResolvedValue("FAKE_INSECURE_TOKEN");
+
+    const retrievedToken = await getPersistedRefreshToken(primaryStorage);
+
+    expect(primarySpy).toHaveBeenCalledWith(StorageKeys.refreshToken);
+    expect(insecureSpy).not.toHaveBeenCalled();
+    expect(retrievedToken).toBe("FAKE_PRIMARY_TOKEN");
+  });
+
+  it("retrieves from active storage when insecure storage is not available", async () => {
+    const primaryStorage = await createSessionStorage({
+      platformOS: "ios",
+    });
+    
+    storageSettings.useInsecureForRefreshToken = true;
+    
+    expect(getInsecureStorage()).toBeNull();
+
+    const primarySpy = vi.spyOn(primaryStorage, "getSessionItem")
+      .mockResolvedValue("FAKE_PRIMARY_TOKEN");
+
+    const retrievedToken = await getPersistedRefreshToken(primaryStorage);
+
+    expect(primarySpy).toHaveBeenCalledWith(StorageKeys.refreshToken);
+    expect(retrievedToken).toBe("FAKE_PRIMARY_TOKEN");
   });
 
   it("uses the Expo secure store loader on native platforms", async () => {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -132,6 +132,21 @@ export const clearPersistedRefreshToken = async (
   }
 };
 
+export const getPersistedRefreshToken = async (
+  storage: SessionManager,
+): Promise<string | null> => {
+  const insecureStorage = getInsecureStorage();
+  if (storageSettings.useInsecureForRefreshToken && insecureStorage) {
+    const token = await insecureStorage.getSessionItem(
+      StorageKeys.refreshToken,
+    );
+    return typeof token === "string" ? token : null;
+  }
+
+  const token = await storage.getSessionItem(StorageKeys.refreshToken);
+  return typeof token === "string" ? token : null;
+};
+
 export const performRemoteLogout = async ({
   discovery,
   redirectUri,

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ export default function Authentication() {
   };
 
   const handleLogout = async () => {
-    await kinde.logout();
+    await kinde.logout({ revokeToken: true });
   };
 
   return !kinde.isAuthenticated ? (


### PR DESCRIPTION
# Explain your changes

This PR restores the token revocation logic that was [removed](https://github.com/kinde-oss/expo/commit/ad8d7e96f15b13be840362edab3d04e0eeb3e6b6) in #132. 

It also extends the original behaviour by revoking the **refresh token** in addition to the access token. 

Now, when you trigger a logout with the revocation flag: 

```ts
logout({ revokeToken: true })
```

Both the access token and the refresh token are revoked.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
